### PR TITLE
[squid:S2131] Primitives should not be boxed just for "String" conver

### DIFF
--- a/app/src/main/java/org/researchstack/sampleapp/DashboardFragment.java
+++ b/app/src/main/java/org/researchstack/sampleapp/DashboardFragment.java
@@ -147,7 +147,7 @@ public class DashboardFragment extends Fragment
         ArrayList<String> xVals = new ArrayList<>();
         for(int i = 0; i < 12; i++)
         {
-            xVals.add(i + "");
+            xVals.add(Integer.toString(i));
         }
 
         ArrayList<BarEntry> yVals1 = new ArrayList<>();
@@ -184,7 +184,7 @@ public class DashboardFragment extends Fragment
         ArrayList<String> xVals = new ArrayList<>();
         for(int i = 0; i < 12; i++)
         {
-            xVals.add(i + "");
+            xVals.add(Integer.toString(i));
         }
 
         ArrayList<BarEntry> yVals1 = new ArrayList<>();
@@ -217,7 +217,7 @@ public class DashboardFragment extends Fragment
         ArrayList<String> xValues = new ArrayList<>();
         for(int i = 0; i < 12; i++)
         {
-            xValues.add(i + "");
+            xValues.add(Integer.toString(i));
         }
 
         ArrayList<Entry> entries = new ArrayList<>();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2131 - “Primitives should not be boxed just for "String" conversion”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131

Please let me know if you have any questions.
Ayman Abdelghany.