### PR TITLE
[squid:UselessImportCheck] Useless imports should be removed

### DIFF
--- a/app/src/main/java/org/researchstack/sampleapp/SampleUiManager.java
+++ b/app/src/main/java/org/researchstack/sampleapp/SampleUiManager.java
@@ -1,10 +1,7 @@
 package org.researchstack.sampleapp;
 import android.content.Context;
 
-import org.researchstack.backbone.answerformat.AnswerFormat;
-import org.researchstack.backbone.answerformat.ChoiceAnswerFormat;
 import org.researchstack.backbone.answerformat.BooleanAnswerFormat;
-import org.researchstack.backbone.model.Choice;
 import org.researchstack.backbone.result.StepResult;
 import org.researchstack.backbone.step.QuestionStep;
 import org.researchstack.backbone.step.FormStep;
@@ -18,8 +15,6 @@ import org.researchstack.skin.ui.fragment.ActivitiesFragment;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Iterator;
 
 public class SampleUiManager extends UiManager
 {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessImportCheck - “Useless imports should be removed”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessImportCheck

Please let me know if you have any questions.
Ayman Abdelghany.